### PR TITLE
Fix renamed files not being in VPC

### DIFF
--- a/mp/src/game/client/client_neo.vpc
+++ b/mp/src/game/client/client_neo.vpc
@@ -155,8 +155,8 @@ $Project "Client (HL2MP)"
 				$File	"neo\ui\neo_hud_game_event.cpp"
 				$File	"neo\ui\neo_hud_game_event.h"
 
-				$File	"neo\ui\neo_hud_ghostbeacon.cpp"
-				$File	"neo\ui\neo_hud_ghostbeacon.h"
+				$File	"neo\ui\neo_hud_ghost_beacons.cpp"
+				$File	"neo\ui\neo_hud_ghost_beacons.h"
 
 				$File	"neo\ui\neo_hud_ghost_marker.cpp"
 				$File	"neo\ui\neo_hud_ghost_marker.h"


### PR DESCRIPTION
"neo_hud_ghostbeacon.cpp" and "neo_hud_ghostbeacon.h" got renamed to "neo_hud_ghost_beacons.cpp" and "neo_hud_ghost_beacons.h"